### PR TITLE
fix:SegFault by unkonwn Target string, and check if already exist f…

### DIFF
--- a/cpp_module_01/Warlock.cpp
+++ b/cpp_module_01/Warlock.cpp
@@ -60,7 +60,10 @@ void Warlock::learnSpell(ASpell* spell)
 void Warlock::forgetSpell(std::string SpellName)
 {
 	if (_SpellBook.find(SpellName) != _SpellBook.end())
+	{	
+		delete _SpellBook[SpellName];
 		_SpellBook.erase(_SpellBook.find(SpellName));
+	}
 }
 
 void Warlock::launchSpell(std::string SpellName, ATarget & target)

--- a/cpp_module_02/ASpell.cpp
+++ b/cpp_module_02/ASpell.cpp
@@ -34,5 +34,7 @@ std::string ASpell::getEffects() const
 
 void ASpell::launch(ATarget const & target) const
 {
-	target.getHitBySpell(*this);
+	const ATarget *tmp = &target; // checking this prevents SegFault 
+	if (tmp)                      // check if target is not unkown/NULL 
+		target.getHitBySpell(*this);
 }

--- a/cpp_module_02/SpellBook.cpp
+++ b/cpp_module_02/SpellBook.cpp
@@ -26,7 +26,11 @@ void SpellBook::learnSpell(ASpell* spell)
 {
 	if (spell)
 	{
-		_SpellBook[spell->getName()] = spell->clone();
+		std::map<std::string, ASpell*>::iterator it = _SpellBook.find(spell->getName()); // avoid adding another if already exist!
+		if (it == _SpellBook.end())													// otherwise it will leak because of clone()
+		{
+			_SpellBook[spell->getName()] = spell->clone();
+		}
 	}
 }
 


### PR DESCRIPTION
fix: SegFault by unkonwn Target string:  If you change in the main the line 
  ATarget* wall = tarGen.createTarget("Inconspicuous Red-brick Wall");
  to
    ATarget* wall = tarGen.createTarget("Inconspicuous  unkown ");
it segfaults.
fixed it by adding a check in ASpell.cpp

also in the learnSpell method in SpellBook.cpp added check if already exist before adding (to avoid duplicate and leaks)