### PR TITLE
Compilation bug fix for JCluzet exam simulator

### DIFF
--- a/cpp_module_01/ATarget.cpp
+++ b/cpp_module_01/ATarget.cpp
@@ -28,5 +28,5 @@ std::string ATarget::getType() const
 
 void	ATarget::getHitBySpell(ASpell const & spell) const
 {
-	std::cout << _type << " has been " << spell.getEffects() << std::endl;
+	std::cout << _type << " has been " << spell.getEffects() << "!" << std::endl;
 }

--- a/cpp_module_01/Warlock.cpp
+++ b/cpp_module_01/Warlock.cpp
@@ -1,6 +1,6 @@
 #include "Warlock.hpp"
 
-Warlock::Warlock(std::string name, std::string title) : _name(name), _title(title)
+Warlock::Warlock(std::string const &name, std::string const &title): _name(name), _title(title)
 {
 	std::cout << _name << ": This looks like another boring day." << std::endl;
 }

--- a/cpp_module_01/Warlock.cpp
+++ b/cpp_module_01/Warlock.cpp
@@ -63,7 +63,7 @@ void Warlock::forgetSpell(std::string SpellName)
 		_SpellBook.erase(_SpellBook.find(SpellName));
 }
 
-void Warlock::launchSpell(std::string SpellName, ATarget & target)
+void Warlock::launchSpell(std::string SpellName, ATarget const & target)
 {
 	if (_SpellBook.find(SpellName) != _SpellBook.end())
 		_SpellBook[SpellName]->launch(target);

--- a/cpp_module_01/Warlock.hpp
+++ b/cpp_module_01/Warlock.hpp
@@ -21,5 +21,5 @@ class Warlock {
 		void	introduce() const;
 		void learnSpell(ASpell* spell);
 		void forgetSpell(std::string SpellName);
-		void launchSpell(std::string SpellName, ATarget & target);
+		void launchSpell(std::string SpellName, ATarget const & target);
 };

--- a/cpp_module_01/Warlock.hpp
+++ b/cpp_module_01/Warlock.hpp
@@ -13,7 +13,7 @@ class Warlock {
 		std::map < std::string, ASpell * > _SpellBook;
 
 	public :
-		Warlock(std::string name, std::string title);
+		Warlock(std::string const &name, std::string const &title);
 		~Warlock();
 		std::string const & getName() const;
 		std::string const & getTitle() const;

--- a/cpp_module_02/ATarget.cpp
+++ b/cpp_module_02/ATarget.cpp
@@ -28,5 +28,5 @@ std::string ATarget::getType() const
 
 void	ATarget::getHitBySpell(ASpell const & spell) const
 {
-	std::cout << _type << " has been " << spell.getEffects() << std::endl;
+	std::cout << _type << " has been " << spell.getEffects() << "!" << std::endl;
 }

--- a/cpp_module_02/Warlock.cpp
+++ b/cpp_module_02/Warlock.cpp
@@ -1,6 +1,6 @@
 #include "Warlock.hpp"
 
-Warlock::Warlock(std::string name, std::string title) : _name(name), _title(title)
+Warlock::Warlock(std::string const &name, std::string const &title) : _name(name), _title(title)
 {
 	std::cout << _name << ": This looks like another boring day." << std::endl;
 }

--- a/cpp_module_02/Warlock.cpp
+++ b/cpp_module_02/Warlock.cpp
@@ -56,7 +56,7 @@ void Warlock::forgetSpell(std::string SpellName)
 	_SpellBook.forgetSpell(SpellName);
 }
 
-void Warlock::launchSpell(std::string SpellName, ATarget & target)
+void Warlock::launchSpell(std::string SpellName, ATarget const & target)
 {
 	if (_SpellBook.createSpell(SpellName))
 		_SpellBook.createSpell(SpellName)->launch(target);

--- a/cpp_module_02/Warlock.hpp
+++ b/cpp_module_02/Warlock.hpp
@@ -23,5 +23,5 @@ class Warlock {
 		void	introduce() const;
 		void learnSpell(ASpell* spell);
 		void forgetSpell(std::string SpellName);
-		void launchSpell(std::string SpellName, ATarget & target);
+		void launchSpell(std::string SpellName, ATarget const & target);
 };

--- a/cpp_module_02/Warlock.hpp
+++ b/cpp_module_02/Warlock.hpp
@@ -15,7 +15,7 @@ class Warlock {
 		Warlock();
 
 	public :
-		Warlock(std::string name, std::string title);
+		Warlock(std::string const &name, std::string const &title);
 		~Warlock();
 		std::string const & getName() const;
 		std::string const & getTitle() const;


### PR DESCRIPTION
The simulator https://github.com/JCluzet/42_EXAM expects some specific declarations in the Warlock class and due to how it's built it won't compile cpp_module01 and 02 even though they'd work just fine and the output with the same main.cpp used for testing would pass the test.
This branch makes the solutions of cpp_module01-02 passing the exam simulator without changing functionality for the other cases.